### PR TITLE
Configurable UserError status codes

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -29,7 +29,7 @@ Let's say you're running a {Sinatra}[http://www.sinatrarb.com/] application that
 exposes some JSON:
 
     require 'sinatra'
-    
+
     get '/ohai' do
       '{"hello":"world"}'
     end
@@ -39,14 +39,14 @@ request:
 
     require 'songkick/transport'
     Transport = Songkick::Transport::Curb
-    
+
     client = Transport.new('http://localhost:4567',
                            :user_agent => 'Test Agent',
                            :timeout    => 5)
-    
+
     response = client.get('/ohai')
     # => Songkick::Transport::Response::OK
-    
+
     response.data
     # => {"hello" => "world"}
 
@@ -56,7 +56,7 @@ takes a reference to a Rack application, for example:
 
     require 'songkick/transport'
     Transport = Songkick::Transport::RackTest
-    
+
     client = Transport.new(Sinatra::Application,
                            :user_agent => 'Test Agent',
                            :timeout    => 5)
@@ -77,7 +77,7 @@ The response's headers are exposed through the +headers+ method, which is an
 immutable hash-like object that normalizes various header conventions.
 
     response = client.get('/users')
-    
+
     # These all return 'application/json'
     response.headers['Content-Type']
     response.headers['content-type']
@@ -103,14 +103,25 @@ has the following properties:
 
 Only responses with status codes, 200 (OK), 201 (Created), 204 (No Content), and
 409 (Conflict) yield response objects. All other status codes cause an exception
-to be raised. We use 409 to indicate user error, i.e. input validation errors as
-opposed to software/infrastructure errors. The response object is typed for the
-status code; the possible types are:
+to be raised.
+
+We use 409 to indicate user error, i.e. input validation errors as
+opposed to software/infrastructure errors. If the response body contains an
+hash in the format <tt>{ "errors":["message"] }</tt>, these errors will be
+available as <tt>response.errors<tt>.
+
+The response object is typed for the status code; the possible types are:
 
 * 200: <tt>Songkick::Transport::Response::OK</tt>
 * 201: <tt>Songkick::Transport::Response::Created</tt>
 * 204: <tt>Songkick::Transport::Response::NoContent</tt>
 * 409: <tt>Songkick::Transport::Response::UserError</tt>
+
+It is also possible to customise the status codes which are treated as
+UserError;
+
+    # config/initializers/songkick-transport.rb
+    Songkick::Transport.user_error_status_codes = [409, 422]
 
 If the request raises an exception, it will be of one of the following types:
 
@@ -206,7 +217,7 @@ params look like:
         :date => "2012-03-01"
       }
     }
-    
+
     file = params[:inventory][:file]
     io = Songkick::Transport::IO.new(file[:tempfile], file[:type], file[:filename])
 
@@ -219,7 +230,7 @@ what you need. The params look like this:
         "date" => "2012-03-01"
       }
     }
-    
+
     file = params["inventory"]["file"]
     io = Songkick::Transport::IO.new(file, file.content_type, file.original_filename)
 
@@ -268,7 +279,7 @@ can use it to create a logging middleware:
       def initialize(app)
         @app = app
       end
-      
+
       def call(env)
         report = Songkick::Transport.report
         response = report.execute { @app.call(env) }

--- a/lib/songkick/transport.rb
+++ b/lib/songkick/transport.rb
@@ -8,13 +8,13 @@ module Songkick
   module Transport
     DEFAULT_TIMEOUT = 5
     DEFAULT_FORMAT  = :json
-    
+
     HTTP_VERBS    = %w[get post put delete head]
     USE_BODY      = %w[post put]
     FORM_ENCODING = 'application/x-www-form-urlencoded'
-    
+
     ROOT = File.expand_path('..', __FILE__)
-    
+
     autoload :Serialization,    ROOT + '/transport/serialization'
     autoload :Base,             ROOT + '/transport/base'
     autoload :Curb,             ROOT + '/transport/curb'
@@ -33,52 +33,56 @@ module Songkick
     autoload :ConnectionFailedError,ROOT + '/transport/upstream_error'
     autoload :InvalidJSONError,     ROOT + '/transport/upstream_error'
     autoload :HttpError,            ROOT + '/transport/http_error'
-    
+
     IO = UploadIO
-    
+
     def self.io(object)
       if Hash === object and [:tempfile, :type, :filename].all? { |k| object.has_key? k } # Rack upload
         Transport::IO.new(object[:tempfile], object[:type], object[:filename])
-        
+
       elsif object.respond_to?(:content_type) and object.respond_to?(:original_filename) # Rails upload
         Transport::IO.new(object, object.content_type, object.original_filename)
-        
+
       else
         raise ArgumentError, "Could not generate a Transport::IO from #{object.inspect}"
       end
     end
-    
+
     def self.logger
       @logger ||= begin
                     require 'logger'
                     Logger.new(STDOUT)
                   end
     end
-    
+
     def self.logger=(logger)
       @logger = logger
     end
-    
+
     def self.verbose=(verbose)
       @verbose = verbose
     end
-    
+
     def self.verbose?
       @verbose
     end
-    
+
     def self.report
       Reporting.report
     end
-    
+
     def self.sanitize(*params)
       sanitized_params.concat(params)
     end
-    
+
     def self.sanitized_params
       @sanitized_params ||= []
     end
-    
+
+    # Allow configurable status codes for UserError
+    def self.user_error_status_codes=(codes)
+      Response::UserError.status_codes = codes
+    end
   end
 end
 

--- a/lib/songkick/transport/response.rb
+++ b/lib/songkick/transport/response.rb
@@ -1,13 +1,13 @@
 module Songkick
   module Transport
-    
+
     class Response
       def self.process(request, status, headers, body)
         case status.to_i
         when 200 then OK.new(status, headers, body)
         when 201 then Created.new(status, headers, body)
         when 204 then NoContent.new(status, headers, body)
-        when 409 then UserError.new(status, headers, body)
+        when *UserError.status_codes then UserError.new(status, headers, body)
         else
           Transport.logger.warn "Received error code: #{status} -- #{request}"
           raise HttpError.new(request, status, headers, body)
@@ -16,30 +16,37 @@ module Songkick
         Transport.logger.warn "Request returned invalid JSON: #{request}"
         raise Transport::InvalidJSONError, request
       end
-      
+
       attr_reader :data, :headers, :status
-      
+
       def initialize(status, headers, body)
         @data = if body.is_a?(String)
                   body.strip == '' ? nil : Yajl::Parser.parse(body)
                 else
                   body
                 end
-        
+
         @headers = Headers.new(headers)
         @status  = status.to_i
       end
-      
+
       def errors
         data && data['errors']
       end
-    
+
       class OK        < Response ; end
       class Created   < Response ; end
       class NoContent < Response ; end
-      class UserError < Response ; end
+
+      class UserError < Response
+        class << self
+          attr_accessor :status_codes
+        end
+
+        self.status_codes = [409]
+      end
     end
-    
+
   end
 end
 

--- a/spec/songkick/transport/response_spec.rb
+++ b/spec/songkick/transport/response_spec.rb
@@ -4,73 +4,90 @@ describe Songkick::Transport::Response do
   def process(*args)
     Songkick::Transport::Response.process(*args)
   end
-  
+
   describe "200 with a body" do
     let(:response) { process("", 200, {}, '{"hello":"world"}') }
-    
+
     it "is an OK" do
       response.should be_a(Songkick::Transport::Response::OK)
     end
-    
+
     it "exposes its data" do
       response.data.should == {"hello" => "world"}
     end
   end
-  
+
   describe "200 with a body with an empty line in it" do
     let(:response) { process("", 200, {}, "{\"hello\":\"world\"\n\n}") }
-    
+
     it "is an OK" do
       response.should be_a(Songkick::Transport::Response::OK)
     end
-    
+
     it "exposes its data" do
       response.data.should == {"hello" => "world"}
     end
   end
-  
+
   describe "200 with a parsed body" do
     let(:response) { process("", 200, {}, {"hello" => "world"}) }
-    
+
     it "exposes its data" do
       response.data.should == {"hello" => "world"}
     end
   end
-  
+
   describe "200 with an empty body" do
     let(:response) { process("", 200, {}, "") }
-    
+
     it "exposes its data" do
       response.data.should be_nil
     end
   end
-  
+
   describe "201 with an empty body" do
     let(:response) { process("", 201, {}, "") }
-    
+
     it "is a Created" do
       response.should be_a(Songkick::Transport::Response::Created)
     end
   end
-  
+
   describe "204 with an empty body" do
     let(:response) { process("", 204, {}, "") }
-    
+
     it "is a NoContent" do
       response.should be_a(Songkick::Transport::Response::NoContent)
     end
   end
-  
+
   describe "409 with a body" do
     let(:response) { process("", 409, {}, '{"errors":[]}') }
-    
+
     it "is a UserError" do
       response.should be_a(Songkick::Transport::Response::UserError)
     end
-    
+
     it "exposes the errors" do
       response.errors.should == []
     end
   end
-end
 
+  describe "a custom UserError Code" do
+    before do
+      Songkick::Transport::Response::UserError.stub(:status_codes).
+        and_return [409,422]
+    end
+
+    let(:response) { process("", 422, {}, '{"errors":[]}') }
+
+    it "is a UserError" do
+      response.should be_a(Songkick::Transport::Response::UserError)
+    end
+
+    it "exposes the errors" do
+      response.errors.should == []
+    end
+  end
+
+end


### PR DESCRIPTION
Various frameworks are opinionated about the status codes they return for user-errors (eg validation failed).

Status codes that are treated as UserError can now be configured;

``` ruby
# config/initializers/songkick-transport.rb
Songkick::Transport.user_error_status_codes = [409, 422]
```

Eg, Rails returns 422 for "validation failed" by default.

There's also a load of diff-cruft because of trailing whitespace removal. Sorry about that!
