### PR TITLE
Allow customer user error codes on a per-client basis

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -131,6 +131,14 @@ If the request raises an exception, it will be of one of the following types:
 * <tt>Songkick::Transport::HttpError</tt> -- we received a response with a
   non-successful status code, e.g. 404 or 500
 
+It is possible to customise the status codes which are treated as UserError
+when initializing the client. Requests responding with any of the provided 
+status codes will then yield a response object with error details, rather than
+raising an exception;
+
+    client = Transport.new('http://localhost:4567',
+                           :user_error_codes => [409, 422])
+
 
 === Registering response parsers
 

--- a/lib/songkick/transport.rb
+++ b/lib/songkick/transport.rb
@@ -8,6 +8,7 @@ module Songkick
   module Transport
     DEFAULT_TIMEOUT = 5
     DEFAULT_FORMAT  = :json
+    DEFAULT_USER_ERROR_CODES = [409]
     
     HTTP_VERBS    = %w[options head get patch post put delete]
     USE_BODY      = %w[post put]

--- a/lib/songkick/transport/base.rb
+++ b/lib/songkick/transport/base.rb
@@ -2,7 +2,7 @@ module Songkick
   module Transport
 
     class Base
-      attr_accessor :user_agent
+      attr_accessor :user_agent, :user_error_codes
 
       HTTP_VERBS.each do |verb|
         class_eval %{
@@ -40,7 +40,7 @@ module Songkick
       private
 
       def process(url, status, headers, body)
-        Response.process(url, status, headers, body)
+        Response.process(url, status, headers, body, @user_error_codes)
       end
 
       def headers

--- a/lib/songkick/transport/curb.rb
+++ b/lib/songkick/transport/curb.rb
@@ -19,6 +19,7 @@ module Songkick
         @host       = host
         @timeout    = options[:timeout] || DEFAULT_TIMEOUT
         @user_agent = options[:user_agent]
+        @user_error_codes = options[:user_error_codes] || DEFAULT_USER_ERROR_CODES
         if c = options[:connection]
           Thread.current[:transport_curb_easy] = c
         end

--- a/lib/songkick/transport/httparty.rb
+++ b/lib/songkick/transport/httparty.rb
@@ -12,6 +12,8 @@ module Songkick
         
         transport = klass.new
         transport.user_agent = options[:user_agent]
+        transport.user_error_codes =
+          options[:user_error_codes] || DEFAULT_USER_ERROR_CODES
         transport
       end
       

--- a/lib/songkick/transport/rack_test.rb
+++ b/lib/songkick/transport/rack_test.rb
@@ -17,6 +17,7 @@ module Songkick
       def initialize(app, options = {})
         @app     = app
         @timeout = options[:timeout] || DEFAULT_TIMEOUT
+        @user_error_codes = options[:user_error_codes] || DEFAULT_USER_ERROR_CODES
       end
       
       HTTP_VERBS.each do |verb|

--- a/lib/songkick/transport/response.rb
+++ b/lib/songkick/transport/response.rb
@@ -2,12 +2,12 @@ module Songkick
   module Transport
     
     class Response
-      def self.process(request, status, headers, body)
+      def self.process(request, status, headers, body, user_error_codes=409)
         case status.to_i
         when 200 then OK.new(status, headers, body)
         when 201 then Created.new(status, headers, body)
         when 204 then NoContent.new(status, headers, body)
-        when 409 then UserError.new(status, headers, body)
+        when *user_error_codes then UserError.new(status, headers, body)
         else
           raise HttpError.new(request, status, headers, body)
         end

--- a/spec/songkick/transport/response_spec.rb
+++ b/spec/songkick/transport/response_spec.rb
@@ -72,5 +72,17 @@ describe Songkick::Transport::Response do
       response.errors.should == []
     end
   end
+
+  describe "422 with customer user error codes" do
+    let(:response) { process("", 422, {"Content-Type" => "application/json"}, '{"errors":[]}', [409, 422]) }
+    
+    it "is a UserError" do
+      response.should be_a(Songkick::Transport::Response::UserError)
+    end
+    
+    it "exposes the errors" do
+      response.errors.should == []
+    end
+  end
 end
 

--- a/spec/songkick/transport_spec.rb
+++ b/spec/songkick/transport_spec.rb
@@ -184,6 +184,19 @@ describe Songkick::Transport do
         @report.total_duration.should == 3.14
       end
     end
+
+    describe "error_status_codes" do
+      let(:codes) { [409, 422] }
+      
+      it "can be provided on initialization" do
+        transport = described_class.new(endpoint, user_error_codes: codes)
+        transport.user_error_codes.should == codes
+      end
+      
+      it "default to 409" do
+        transport.user_error_codes.should == [409]
+      end
+    end
   end
 
   describe Songkick::Transport::Curb do


### PR DESCRIPTION
Various frameworks are opinionated about the status codes they return for user-errors (e.g., Rails returns 422 for "validation failed" by default). This PR allows the status codes regarded as user-error to be set when initializing the client

```
client = Transport.new('http://localhost:4567',
                       :user_error_codes => [409, 422])
```

Largely lifted from https://github.com/songkick/transport/pull/2.
