### PR TITLE
Add Ruby 2.1.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
-  - rbx-18mode
+  - 2.1.2
 
 script: bundle exec rspec spec/
-


### PR DESCRIPTION
Would be great to know that Ruby 2.1.2 is supported. This PR also removes 1.8.7 and 1.9.2 support (the builds had been erroring for several months, so hopefully this isn't a big deal). 
